### PR TITLE
Compatibility with OCaml 5.0.0

### DIFF
--- a/opam
+++ b/opam
@@ -7,8 +7,8 @@ homepage: "https://github.com/arlencox/SETr"
 bug-reports: "https://github.com/arlencox/SETr/issues"
 license: "MIT"
 dev-repo: "https://github.com/arlencox/SETr.git"
-build: [make]
+build: [["./configure"] [make]]
 install: [make "install"]
 remove: ["ocamlfind" "remove" "setr"]
 depends: [ "ocamlfind" {build} "cppo" {build} "mlbdd" ]
-available: [ ocaml-version >= "4.01.0" ]
+available: [ ocaml-version >= "4.07" ]

--- a/setup.ml
+++ b/setup.ml
@@ -1,6 +1,6 @@
 #use "topfind"
-#require "findlib"
 #require "str"
+#require "findlib"
 
 
 let mandatory_packages = [

--- a/src/setr/SETr_DS_PSet.ml
+++ b/src/setr/SETr_DS_PSet.ml
@@ -323,17 +323,17 @@ module Compare = struct
 
 end
 
-let add x set = Compare.add Pervasives.compare x set
-let mem x set = Compare.mem Pervasives.compare x set
-let remove x set = Compare.remove Pervasives.compare x set
-let union s1 s2 = Compare.union Pervasives.compare s1 s2
-let inter s1 s2 = Compare.inter Pervasives.compare s1 s2
-let diff s1 s2 = Compare.diff Pervasives.compare s1 s2
-let compare s1 s2 = Compare.compare Pervasives.compare s1 s2
-let equal s1 s2 = Compare.equal Pervasives.compare s1 s2
-let subset s1 s2 = Compare.subset Pervasives.compare s1 s2
-let filter f s = Compare.filter Pervasives.compare f s
-let partition f s = Compare.partition Pervasives.compare f s
+let add x set = Compare.add Stdlib.compare x set
+let mem x set = Compare.mem Stdlib.compare x set
+let remove x set = Compare.remove Stdlib.compare x set
+let union s1 s2 = Compare.union Stdlib.compare s1 s2
+let inter s1 s2 = Compare.inter Stdlib.compare s1 s2
+let diff s1 s2 = Compare.diff Stdlib.compare s1 s2
+let compare s1 s2 = Compare.compare Stdlib.compare s1 s2
+let equal s1 s2 = Compare.equal Stdlib.compare s1 s2
+let subset s1 s2 = Compare.subset Stdlib.compare s1 s2
+let filter f s = Compare.filter Stdlib.compare f s
+let partition f s = Compare.partition Stdlib.compare f s
 
 (** Output signature of the functor {!Sette.Make}. *)
 module type S =


### PR DESCRIPTION
This commit makes SETr compatible with OCaml 5.0.0:
- `Pervasives` is no longer available, use `Stdlib` instead (introduced in 4.07);
- for a strange reason, `#require "str"` should occur before `#require "findlib"` in `setup.ml`, or else `Str` module is unbound;
- `opam` should run `./configure` before `make`.